### PR TITLE
First cli: init, build, publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Crossplane Stacks CLI
+
+## Installation
+
+Get the commands on the PATH so `kubectl` can pick them up:
+```
+curl -o /usr/local/bin/kubectl-crossplane-stack-build https://raw.githubusercontent.com/suskin/crossplane-stack-cli/first-cli/bin/kubectl-crossplane-stack-build -s >/dev/null
+curl -o /usr/local/bin/kubectl-crossplane-stack-init https://raw.githubusercontent.com/suskin/crossplane-stack-cli/first-cli/bin/kubectl-crossplane-stack-init -s >/dev/null
+curl -o /usr/local/bin/kubectl-crossplane-stack-publish https://raw.githubusercontent.com/suskin/crossplane-stack-cli/first-cli/bin/kubectl-crossplane-stack-publish -s >/dev/null
+chmod +x /usr/local/bin/kubectl-crossplane-stack-*
+```
+
+## Usage
+
+```
+kubectl crossplane stack init 'myname/mysubname'
+kubectl crossplane stack build
+kubectl crossplane stack publish
+```
+
+
+

--- a/bin/kubectl-crossplane-stack-build
+++ b/bin/kubectl-crossplane-stack-build
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+
+COMMAND=${1:-build}
+shift
+
+# Shift returns non-zero if there are no arguments left,
+# so we wait until after `shift` to set -e
+set -e
+set -x
+
+make -f Makefile.stack ${COMMAND} "$@"

--- a/bin/kubectl-crossplane-stack-build
+++ b/bin/kubectl-crossplane-stack-build
@@ -9,4 +9,4 @@ shift
 set -e
 set -x
 
-make -f Makefile.stack ${COMMAND} "$@"
+make -f stack.Makefile ${COMMAND} "$@"

--- a/bin/kubectl-crossplane-stack-init
+++ b/bin/kubectl-crossplane-stack-init
@@ -38,13 +38,6 @@ EOF
 
   echo 'Created config/stack/manifests/app.yaml' >&2
 
-  touch config/stack/manifests/rbac.yaml
-  cat > config/stack/manifests/rbac.yaml <<'EOF'
----
-# Put your rbac rules here
-EOF
-  echo 'Created config/stack/manifests/rbac.yaml' >&2
-
   touch config/stack/manifests/install.yaml
   cat > config/stack/manifests/install.yaml <<EOF
 apiVersion: apps/v1
@@ -153,6 +146,10 @@ EOF
 IMG ?= ${STACK_NAME}:latest
 
 CRD_DIR=config/crd/bases
+# Files matching this glob will be placed into the stack's
+# rbac.yaml. It could be multiple filenames or multiple
+# glob patterns.
+RBAC_GLOB=config/rbac/role.yaml
 STACK_PACKAGE_REGISTRY_SOURCE=config/stack/manifests
 LOCAL_OVERRIDES_DIR=config/stack/overrides
 CONFIG_SAMPLES_DIR=config/stack/samples
@@ -224,6 +221,10 @@ bundle: $(STACK_PACKAGE_REGISTRY)
 		while read filename ; do cat $$filename > \
 		$(STACK_PACKAGE_REGISTRY)/resources/$$( basename $${filename/.yaml/.crd.yaml} ) \
 		; done
+
+	# If RBAC_GLOB is set *and* there is an rbac.yaml in the registry
+	# source folder, the registry source will win.
+	cat $(RBAC_GLOB) > $(STACK_PACKAGE_REGISTRY)/rbac.yaml
 	cp -r $(STACK_PACKAGE_REGISTRY_SOURCE)/* $(STACK_PACKAGE_REGISTRY)
 .PHONY: bundle
 

--- a/bin/kubectl-crossplane-stack-init
+++ b/bin/kubectl-crossplane-stack-init
@@ -126,11 +126,18 @@ COPY --from=builder /workspace/manager .
 ENTRYPOINT ["/manager"]
 EOF
 
-  cat > Makefile.stack <<'EOF'
+  cat > env.stack <<EOF
 # Image URL to use all building/pushing image targets
-IMG ?= crossplane-examples/wordpress-stack:latest
-# Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:trivialVersions=true"
+IMG ?= ${STACK_NAME}:latest
+
+CRD_DIR=config/crd/bases
+STACK_PACKAGE_REGISTRY_SOURCE=config/stack/manifests
+LOCAL_OVERRIDES_DIR=config/samples/overrides
+CONFIG_SAMPLES_DIR=config/stack/samples
+EOF
+
+  cat > Makefile.stack <<'EOF'
+include env.stack
 
 GO111MODULE ?= on
 export GO111MODULE
@@ -142,13 +149,9 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
-CRD_DIR=config/crd/bases
-LOCAL_OVERRIDES_DIR=config/samples/overrides
 
-EXTENSION_PACKAGE=extension-package
-EXTENSION_PACKAGE_REGISTRY=$(EXTENSION_PACKAGE)/.registry
-EXTENSION_PACKAGE_REGISTRY_SOURCE=config/stack/manifests
-CONFIG_SAMPLES_DIR=config/stack/samples
+STACK_PACKAGE=stack-package
+STACK_PACKAGE_REGISTRY=$(STACK_PACKAGE)/.registry
 
 all: build
 
@@ -167,23 +170,23 @@ all: build
 #
 ################################################
 
-clean: clean-extension-package clean-binary
+clean: clean-stack-package clean-binary
 .PHONY: clean
 
-clean-extension-package:
-	rm -r $(EXTENSION_PACKAGE)
-.PHONY: clean-extension-package
+clean-stack-package:
+	rm -r $(STACK_PACKAGE)
+.PHONY: clean-stack-package
 
 clean-binary:
 	rm -r bin
 .PHONY: clean-binary
 
 # Initialize the stack bundle folder
-$(EXTENSION_PACKAGE_REGISTRY):
-	mkdir -p $(EXTENSION_PACKAGE_REGISTRY)/resources
-	touch $(EXTENSION_PACKAGE_REGISTRY)/app.yaml $(EXTENSION_PACKAGE_REGISTRY)/install.yaml $(EXTENSION_PACKAGE_REGISTRY)/rbac.yaml
+$(STACK_PACKAGE_REGISTRY):
+	mkdir -p $(STACK_PACKAGE_REGISTRY)/resources
+	touch $(STACK_PACKAGE_REGISTRY)/app.yaml $(STACK_PACKAGE_REGISTRY)/install.yaml $(STACK_PACKAGE_REGISTRY)/rbac.yaml
 
-build: manager manifests $(EXTENSION_PACKAGE_REGISTRY)
+build: manager manifests $(STACK_PACKAGE_REGISTRY)
 	# Copy CRDs over
 	#
 	# The reason this looks complicated is because it is
@@ -194,9 +197,9 @@ build: manager manifests $(EXTENSION_PACKAGE_REGISTRY)
 	# be to cat all of the files into a single crd.yaml.
 	find $(CRD_DIR) -type f -name '*.yaml' | \
 		while read filename ; do cat $$filename > \
-		$(EXTENSION_PACKAGE_REGISTRY)/resources/$$( basename $${filename/.yaml/.crd.yaml} ) \
+		$(STACK_PACKAGE_REGISTRY)/resources/$$( basename $${filename/.yaml/.crd.yaml} ) \
 		; done
-	cp -r $(EXTENSION_PACKAGE_REGISTRY_SOURCE)/* $(EXTENSION_PACKAGE_REGISTRY)
+	cp -r $(STACK_PACKAGE_REGISTRY_SOURCE)/* $(STACK_PACKAGE_REGISTRY)
 .PHONY: build
 
 # A local docker registry can be used to publish and consume images locally, which
@@ -229,20 +232,20 @@ docker-local-push: docker-local-tag
 # The way this has been implemented here is by having the base install yaml be the
 # production install, with a yaml patch on the side for use during development.
 # *This* make recipe creates the development install yaml, which requires doing
-# some patching of the original install and putting it back in the extension package
-# directory. It's done here as a post-processing step after the extension package
+# some patching of the original install and putting it back in the stack package
+# directory. It's done here as a post-processing step after the stack package
 # has been generated, which is why the output to a copy and then rename step is
 # needed. This is not the only way to implement this functionality.
 #
 # The implementation here is general, in the sense that any other yamls in the
 # overrides directory will be patched into their corresponding files in the
-# extension package. It assumes that all of the yamls are only one level deep.
+# stack package. It assumes that all of the yamls are only one level deep.
 stack-local-build: build
 	find $(LOCAL_OVERRIDES_DIR) -maxdepth 1 -type f -name '*.yaml' | \
 		while read filename ; do \
-			kubectl patch --dry-run --filename $(EXTENSION_PACKAGE_REGISTRY)/$$( basename $$filename ) \
-				--type strategic --output yaml --patch "$$( cat $$filename )" > $(EXTENSION_PACKAGE_REGISTRY)/$$( basename $$filename ).new && \
-			mv $(EXTENSION_PACKAGE_REGISTRY)/$$( basename $$filename ).new $(EXTENSION_PACKAGE_REGISTRY)/$$( basename $$filename ) \
+			kubectl patch --dry-run --filename $(STACK_PACKAGE_REGISTRY)/$$( basename $$filename ) \
+				--type strategic --output yaml --patch "$$( cat $$filename )" > $(STACK_PACKAGE_REGISTRY)/$$( basename $$filename ).new && \
+			mv $(STACK_PACKAGE_REGISTRY)/$$( basename $$filename ).new $(STACK_PACKAGE_REGISTRY)/$$( basename $$filename ) \
 		; done
 .PHONY: stack-local-build
 
@@ -250,13 +253,13 @@ stack-local-build: build
 local-build: stack-local-build docker-build docker-local-push
 .PHONY: local-build
 
-# Install a locally-built stack using the sample extension installation CR
+# Install a locally-built stack using the sample stack installation CR
 stack-install:
-	kubectl apply -f $(CONFIG_SAMPLES_DIR)/install.extension.yaml
+	kubectl apply -f $(CONFIG_SAMPLES_DIR)/local.install.stack.yaml
 .PHONY: stack-install
 
 stack-uninstall:
-	kubectl delete -f $(CONFIG_SAMPLES_DIR)/install.extension.yaml
+	kubectl delete -f $(CONFIG_SAMPLES_DIR)/local.install.stack.yaml
 .PHONY: stack-uninstall
 
 # Build the docker image

--- a/bin/kubectl-crossplane-stack-init
+++ b/bin/kubectl-crossplane-stack-init
@@ -21,6 +21,9 @@ STACK_NAME=${1}
 # slashes are common for docker image names. So we remove the
 # slashes before we use the name for kubernetes resource fields.
 KUBEY_STACK_NAME=$( echo ${STACK_NAME} | tr '/' '-' )
+# This is mostly for code clarity, but it's possible that the
+# image name won't be the passed-in stack name in the future.
+STACK_IMAGE_NAME=${STACK_NAME}
 INIT_DIR=${2:-$PWD}
 
 function create_dirs {
@@ -63,7 +66,7 @@ spec:
     spec:
       containers:
       - name: "${KUBEY_STACK_NAME}-controller"
-        image: "${KUBEY_STACK_NAME}"
+        image: "${STACK_IMAGE_NAME}"
         env:
         - name: POD_NAME
           valueFrom:
@@ -109,7 +112,7 @@ spec:
     spec:
       containers:
       - name: "${KUBEY_STACK_NAME}-controller"
-        image: "localhost:5000/${STACK_NAME}"
+        image: "localhost:5000/${STACK_IMAGE_NAME}"
 EOF
   echo 'Created config/stack/samples/overrides/install.yaml' >&2
 }

--- a/bin/kubectl-crossplane-stack-init
+++ b/bin/kubectl-crossplane-stack-init
@@ -23,17 +23,17 @@ function create_dirs {
 }
 
 function create_manifest {
-  mkdir -p config/stack/manifest
-  touch config/stack/manifest/app.yaml
-  cat > config/stack/manifest/app.yaml <<'EOF'
+  mkdir -p config/stack/manifests
+  touch config/stack/manifests/app.yaml
+  cat > config/stack/manifests/app.yaml <<'EOF'
 EOF
-  touch config/stack/manifest/rbac.yaml
-  cat > config/stack/manifest/rbac.yaml <<'EOF'
+  touch config/stack/manifests/rbac.yaml
+  cat > config/stack/manifests/rbac.yaml <<'EOF'
 ---
 # Put your rbac rules here
 EOF
-  touch config/stack/manifest/install.yaml
-  cat > config/stack/manifest/install.yaml <<EOF
+  touch config/stack/manifests/install.yaml
+  cat > config/stack/manifests/install.yaml <<EOF
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -180,7 +180,7 @@ $(STACK_PACKAGE_REGISTRY):
 	mkdir -p $(STACK_PACKAGE_REGISTRY)/resources
 	touch $(STACK_PACKAGE_REGISTRY)/app.yaml $(STACK_PACKAGE_REGISTRY)/install.yaml $(STACK_PACKAGE_REGISTRY)/rbac.yaml
 
-build: manager manifests $(STACK_PACKAGE_REGISTRY)
+build: $(STACK_PACKAGE_REGISTRY)
 	# Copy CRDs over
 	#
 	# The reason this looks complicated is because it is

--- a/bin/kubectl-crossplane-stack-init
+++ b/bin/kubectl-crossplane-stack-init
@@ -204,12 +204,14 @@ clean-binary:
 	rm -r bin
 .PHONY: clean-binary
 
+build: bundle docker-build
+
 # Initialize the stack bundle folder
 $(STACK_PACKAGE_REGISTRY):
 	mkdir -p $(STACK_PACKAGE_REGISTRY)/resources
 	touch $(STACK_PACKAGE_REGISTRY)/app.yaml $(STACK_PACKAGE_REGISTRY)/install.yaml $(STACK_PACKAGE_REGISTRY)/rbac.yaml
 
-build: $(STACK_PACKAGE_REGISTRY)
+bundle: $(STACK_PACKAGE_REGISTRY)
 	# Copy CRDs over
 	#
 	# The reason this looks complicated is because it is
@@ -223,24 +225,25 @@ build: $(STACK_PACKAGE_REGISTRY)
 		$(STACK_PACKAGE_REGISTRY)/resources/$$( basename $${filename/.yaml/.crd.yaml} ) \
 		; done
 	cp -r $(STACK_PACKAGE_REGISTRY_SOURCE)/* $(STACK_PACKAGE_REGISTRY)
-.PHONY: build
+.PHONY: bundle
 
 # A local docker registry can be used to publish and consume images locally, which
 # is convenient during development, as it simulates the whole lifecycle of the
 # Stack, end-to-end.
 docker-local-registry:
-	docker run -d -p 5000:5000 --restart=always --name registry registry:2
+	[[ $$( docker ps --filter name=registry --filter status=running --last 1 --quiet | wc -l ) -eq 1 ]] || \
+		docker run -d -p 5000:5000 --restart=always --name registry registry:2
 .PHONY: docker-local-registry
 
 # Tagging the image with the address of the local registry is a necessary step of
 # publishing the image to the local registry.
-docker-local-tag:
+docker-local-tag: docker-local-registry
 	docker tag ${IMG} localhost:5000/${IMG}
 .PHONY: docker-local-tag
 
 # When we are developing locally, this target will publish our container image
 # to the local registry.
-docker-local-push: docker-local-tag
+docker-local-push: docker-local-tag docker-local-registry
 	docker push localhost:5000/${IMG}
 .PHONY: docker-local-push
 
@@ -263,7 +266,7 @@ docker-local-push: docker-local-tag
 # The implementation here is general, in the sense that any other yamls in the
 # overrides directory will be patched into their corresponding files in the
 # stack package. It assumes that all of the yamls are only one level deep.
-stack-local-build: build
+stack-local-build: bundle
 	find $(LOCAL_OVERRIDES_DIR) -maxdepth 1 -type f -name '*.yaml' | \
 		while read filename ; do \
 			kubectl patch --dry-run --filename $(STACK_PACKAGE_REGISTRY)/$$( basename $$filename ) \
@@ -286,7 +289,7 @@ stack-uninstall:
 .PHONY: stack-uninstall
 
 # Build the docker image
-docker-build: test
+docker-build: bundle
 	docker build --file stack.Dockerfile . -t ${IMG}
 	@echo "updating kustomize image patch file for manager resource"
 	@# The argument to sed -i and the subsequent rm make the in-place sed work well on MacOS.
@@ -295,6 +298,8 @@ docker-build: test
 	sed -i '.bak' -e 's@image: .*@image: '"${IMG}"'@' ./config/default/manager_image_patch.yaml
 	rm ./config/default/manager_image_patch.yaml.bak
 
+docker-push:
+	docker push ${IMG}
 EOF
   echo 'Created stack.Makefile' >&2
 }

--- a/bin/kubectl-crossplane-stack-init
+++ b/bin/kubectl-crossplane-stack-init
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+
+set -e
+
+function usage {
+  echo "Usage: kubectl crossplane stack init STACK_NAME [DIRECTORY]" >&2
+  echo "" >&2
+  echo "DIRECTORY defaults to the current directory." >&2
+}
+
+if [[ $# -lt 1 ]] ; then
+  usage
+  exit 1
+fi
+
+set -x
+
+STACK_NAME=${1}
+INIT_DIR=${2:-$PWD}
+
+# Create dirs
+# Create manifest files
+# Create sample install file
+# Create Dockerfile
+# Create Makefile
+
+function create_dirs {
+  mkdir -p config/stack
+}
+
+function create_manifest {
+  mkdir -p config/stack/manifest
+  touch config/stack/manifest/app.yaml
+  cat > config/stack/manifest/app.yaml <<'EOF'
+EOF
+  touch config/stack/manifest/rbac.yaml
+  cat > config/stack/manifest/rbac.yaml <<'EOF'
+---
+# Put your rbac rules here
+EOF
+  touch config/stack/manifest/install.yaml
+  cat > config/stack/manifest/install.yaml <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "${STACK_NAME}"
+  labels:
+    core.crossplane.io/name: "${STACK_NAME}"
+spec:
+  selector:
+    matchLabels:
+      core.crossplane.io/name: "${STACK_NAME}"
+  replicas: 1
+  template:
+    metadata:
+      name: "${STACK_NAME}-controller"
+      labels:
+        core.crossplane.io/name: "${STACK_NAME}"
+    spec:
+      containers:
+      - name: "${STACK_NAME}-controller"
+        image: "${STACK_NAME}"
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+EOF
+}
+
+function create_samples {
+  mkdir -p config/stack/samples
+  cat > config/stack/samples/local.install.stack.yaml <<EOF
+---
+apiVersion: extensions.crossplane.io/v1alpha1
+kind: ExtensionRequest
+metadata:
+  name: "${STACK_NAME}"
+spec:
+  source: localhost:5000
+  package: "${STACK_NAME}"
+EOF
+
+  cat > config/stack/samples/install.stack.yaml <<EOF
+---
+apiVersion: extensions.crossplane.io/v1alpha1
+kind: ExtensionRequest
+metadata:
+  name: "${STACK_NAME}"
+spec:
+  package: "${STACK_NAME}"
+EOF
+}
+
+function create_build {
+  cat > Dockerfile.stack <<'EOF'
+# Build the manager binary
+FROM golang:1.12.5 as builder
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY main.go main.go
+COPY api/ api/
+COPY controllers/ controllers/
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+
+# Use alpine as a minimal base image to package the manager binary
+# Alpine is used instead of distroless because the stack manager expects things like `cp` to exist
+FROM alpine:3.7
+WORKDIR /
+COPY extension-package /
+COPY --from=builder /workspace/manager .
+ENTRYPOINT ["/manager"]
+EOF
+
+  cat > Makefile.stack <<'EOF'
+# Image URL to use all building/pushing image targets
+IMG ?= crossplane-examples/wordpress-stack:latest
+# Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
+CRD_OPTIONS ?= "crd:trivialVersions=true"
+
+GO111MODULE ?= on
+export GO111MODULE
+
+# Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
+ifeq (,$(shell go env GOBIN))
+GOBIN=$(shell go env GOPATH)/bin
+else
+GOBIN=$(shell go env GOBIN)
+endif
+
+CRD_DIR=config/crd/bases
+LOCAL_OVERRIDES_DIR=config/samples/overrides
+
+EXTENSION_PACKAGE=extension-package
+EXTENSION_PACKAGE_REGISTRY=$(EXTENSION_PACKAGE)/.registry
+EXTENSION_PACKAGE_REGISTRY_SOURCE=config/stack/manifests
+CONFIG_SAMPLES_DIR=config/stack/samples
+
+all: build
+
+################################################
+#
+# Below this until marked otherwise is where
+# most of the build customizations beyond
+# what kubebuilder generates live.
+#
+# Here are some other customizations of note:
+# - Set IMG above to be more specific
+# - Add GO111MODULE=on
+# - Add COPY of stack bundle in Dockerfile
+# - Add some other make variables
+# - Made docker-build recipe work well on MacOS
+#
+################################################
+
+clean: clean-extension-package clean-binary
+.PHONY: clean
+
+clean-extension-package:
+	rm -r $(EXTENSION_PACKAGE)
+.PHONY: clean-extension-package
+
+clean-binary:
+	rm -r bin
+.PHONY: clean-binary
+
+# Initialize the stack bundle folder
+$(EXTENSION_PACKAGE_REGISTRY):
+	mkdir -p $(EXTENSION_PACKAGE_REGISTRY)/resources
+	touch $(EXTENSION_PACKAGE_REGISTRY)/app.yaml $(EXTENSION_PACKAGE_REGISTRY)/install.yaml $(EXTENSION_PACKAGE_REGISTRY)/rbac.yaml
+
+build: manager manifests $(EXTENSION_PACKAGE_REGISTRY)
+	# Copy CRDs over
+	#
+	# The reason this looks complicated is because it is
+	# preserving the original crd filenames and changing
+	# *.yaml to *.crd.yaml.
+	#
+	# An alternate and simpler-looking approach would
+	# be to cat all of the files into a single crd.yaml.
+	find $(CRD_DIR) -type f -name '*.yaml' | \
+		while read filename ; do cat $$filename > \
+		$(EXTENSION_PACKAGE_REGISTRY)/resources/$$( basename $${filename/.yaml/.crd.yaml} ) \
+		; done
+	cp -r $(EXTENSION_PACKAGE_REGISTRY_SOURCE)/* $(EXTENSION_PACKAGE_REGISTRY)
+.PHONY: build
+
+# A local docker registry can be used to publish and consume images locally, which
+# is convenient during development, as it simulates the whole lifecycle of the
+# Stack, end-to-end.
+docker-local-registry:
+	docker run -d -p 5000:5000 --restart=always --name registry registry:2
+.PHONY: docker-local-registry
+
+# Tagging the image with the address of the local registry is a necessary step of
+# publishing the image to the local registry.
+docker-local-tag:
+	docker tag ${IMG} localhost:5000/${IMG}
+.PHONY: docker-local-tag
+
+# When we are developing locally, this target will publish our container image
+# to the local registry.
+docker-local-push: docker-local-tag
+	docker push localhost:5000/${IMG}
+.PHONY: docker-local-push
+
+# Sooo ideally this wouldn't be a single line, but the idea here is that when we're
+# developing locally, we want to use our locally-published container image for the
+# Stack's controller container. The container image is specified in the install
+# yaml for the Stack. This means we need two versions of the install:
+#
+# * One for "regular", production publishing
+# * One for development
+#
+# The way this has been implemented here is by having the base install yaml be the
+# production install, with a yaml patch on the side for use during development.
+# *This* make recipe creates the development install yaml, which requires doing
+# some patching of the original install and putting it back in the extension package
+# directory. It's done here as a post-processing step after the extension package
+# has been generated, which is why the output to a copy and then rename step is
+# needed. This is not the only way to implement this functionality.
+#
+# The implementation here is general, in the sense that any other yamls in the
+# overrides directory will be patched into their corresponding files in the
+# extension package. It assumes that all of the yamls are only one level deep.
+stack-local-build: build
+	find $(LOCAL_OVERRIDES_DIR) -maxdepth 1 -type f -name '*.yaml' | \
+		while read filename ; do \
+			kubectl patch --dry-run --filename $(EXTENSION_PACKAGE_REGISTRY)/$$( basename $$filename ) \
+				--type strategic --output yaml --patch "$$( cat $$filename )" > $(EXTENSION_PACKAGE_REGISTRY)/$$( basename $$filename ).new && \
+			mv $(EXTENSION_PACKAGE_REGISTRY)/$$( basename $$filename ).new $(EXTENSION_PACKAGE_REGISTRY)/$$( basename $$filename ) \
+		; done
+.PHONY: stack-local-build
+
+# Convenience for building a local bundle by running the steps in the right order and with a single command
+local-build: stack-local-build docker-build docker-local-push
+.PHONY: local-build
+
+# Install a locally-built stack using the sample extension installation CR
+stack-install:
+	kubectl apply -f $(CONFIG_SAMPLES_DIR)/install.extension.yaml
+.PHONY: stack-install
+
+stack-uninstall:
+	kubectl delete -f $(CONFIG_SAMPLES_DIR)/install.extension.yaml
+.PHONY: stack-uninstall
+
+# Build the docker image
+docker-build: test
+	docker build --file Dockerfile.stack . -t ${IMG}
+	@echo "updating kustomize image patch file for manager resource"
+	@# The argument to sed -i and the subsequent rm make the in-place sed work well on MacOS.
+	@# There is no good way to do an in-place replacement with sed without leaving behind a
+	@# temporary file.
+	sed -i '.bak' -e 's@image: .*@image: '"${IMG}"'@' ./config/default/manager_image_patch.yaml
+	rm ./config/default/manager_image_patch.yaml.bak
+
+EOF
+}
+
+create_dirs
+create_manifest
+create_samples
+create_build
+

--- a/bin/kubectl-crossplane-stack-init
+++ b/bin/kubectl-crossplane-stack-init
@@ -105,8 +105,8 @@ spec:
 EOF
   echo 'Created config/stack/samples/install.stack.yaml' >&2
 
-  mkdir -p config/stack/samples/overrides
-  cat > config/stack/samples/overrides/install.yaml <<EOF
+  mkdir -p config/stack/overrides
+  cat > config/stack/overrides/install.yaml <<EOF
 spec:
   template:
     spec:
@@ -114,7 +114,7 @@ spec:
       - name: "${KUBEY_STACK_NAME}-controller"
         image: "localhost:5000/${STACK_IMAGE_NAME}"
 EOF
-  echo 'Created config/stack/samples/overrides/install.yaml' >&2
+  echo 'Created config/stack/overrides/install.yaml' >&2
 }
 
 function create_build {
@@ -154,7 +154,7 @@ IMG ?= ${STACK_NAME}:latest
 
 CRD_DIR=config/crd/bases
 STACK_PACKAGE_REGISTRY_SOURCE=config/stack/manifests
-LOCAL_OVERRIDES_DIR=config/stack/samples/overrides
+LOCAL_OVERRIDES_DIR=config/stack/overrides
 CONFIG_SAMPLES_DIR=config/stack/samples
 EOF
   echo 'Created stack.env' >&2

--- a/bin/kubectl-crossplane-stack-init
+++ b/bin/kubectl-crossplane-stack-init
@@ -90,7 +90,7 @@ metadata:
   name: "${KUBEY_STACK_NAME}"
 spec:
   source: localhost:5000
-  package: "${KUBEY_STACK_NAME}"
+  package: "${STACK_IMAGE_NAME}"
 EOF
   echo 'Created config/stack/samples/local.install.stack.yaml' >&2
 
@@ -101,7 +101,7 @@ kind: StackRequest
 metadata:
   name: "${KUBEY_STACK_NAME}"
 spec:
-  package: "${KUBEY_STACK_NAME}"
+  package: "${STACK_IMAGE_NAME}"
 EOF
   echo 'Created config/stack/samples/install.stack.yaml' >&2
 

--- a/bin/kubectl-crossplane-stack-init
+++ b/bin/kubectl-crossplane-stack-init
@@ -5,6 +5,9 @@ set -e
 function usage {
   echo "Usage: kubectl crossplane stack init STACK_NAME [DIRECTORY]" >&2
   echo "" >&2
+  echo "STACK_NAME is used as the image name for the stack, and any '/' characters" >&2
+  echo "are converted to '-' characters when populating kubernetes resource field names." >&2
+  echo "" >&2
   echo "DIRECTORY defaults to the current directory." >&2
 }
 
@@ -16,6 +19,10 @@ fi
 set -x
 
 STACK_NAME=${1}
+# For kubernetes fields, we aren't able to use slashes, and
+# slashes are common for docker image names. So we remove the
+# slashes before we use the name for kubernetes resource fields.
+KUBEY_STACK_NAME=$( echo ${STACK_NAME} | tr '/' '-' )
 INIT_DIR=${2:-$PWD}
 
 function create_dirs {
@@ -37,23 +44,23 @@ EOF
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "${STACK_NAME}"
+  name: "${KUBEY_STACK_NAME}"
   labels:
-    core.crossplane.io/name: "${STACK_NAME}"
+    core.crossplane.io/name: "${KUBEY_STACK_NAME}"
 spec:
   selector:
     matchLabels:
-      core.crossplane.io/name: "${STACK_NAME}"
+      core.crossplane.io/name: "${KUBEY_STACK_NAME}"
   replicas: 1
   template:
     metadata:
-      name: "${STACK_NAME}-controller"
+      name: "${KUBEY_STACK_NAME}-controller"
       labels:
-        core.crossplane.io/name: "${STACK_NAME}"
+        core.crossplane.io/name: "${KUBEY_STACK_NAME}"
     spec:
       containers:
-      - name: "${STACK_NAME}-controller"
-        image: "${STACK_NAME}"
+      - name: "${KUBEY_STACK_NAME}-controller"
+        image: "${KUBEY_STACK_NAME}"
         env:
         - name: POD_NAME
           valueFrom:
@@ -70,23 +77,32 @@ function create_samples {
   mkdir -p config/stack/samples
   cat > config/stack/samples/local.install.stack.yaml <<EOF
 ---
-apiVersion: extensions.crossplane.io/v1alpha1
-kind: ExtensionRequest
+apiVersion: stacks.crossplane.io/v1alpha1
+kind: StackRequest
 metadata:
-  name: "${STACK_NAME}"
+  name: "${KUBEY_STACK_NAME}"
 spec:
   source: localhost:5000
-  package: "${STACK_NAME}"
+  package: "${KUBEY_STACK_NAME}"
 EOF
 
   cat > config/stack/samples/install.stack.yaml <<EOF
 ---
-apiVersion: extensions.crossplane.io/v1alpha1
-kind: ExtensionRequest
+apiVersion: stacks.crossplane.io/v1alpha1
+kind: StackRequest
 metadata:
-  name: "${STACK_NAME}"
+  name: "${KUBEY_STACK_NAME}"
 spec:
-  package: "${STACK_NAME}"
+  package: "${KUBEY_STACK_NAME}"
+EOF
+
+  cat > config/stack/samples/overrides/install.yaml <<EOF
+spec:
+  template:
+    spec:
+      containers:
+      - name: "${KUBEY_STACK_NAME}-controller"
+        image: "localhost:5000/${STACK_NAME}"
 EOF
 }
 
@@ -115,7 +131,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager 
 # Alpine is used instead of distroless because the stack manager expects things like `cp` to exist
 FROM alpine:3.7
 WORKDIR /
-COPY extension-package /
+COPY stack-package /
 COPY --from=builder /workspace/manager .
 ENTRYPOINT ["/manager"]
 EOF

--- a/bin/kubectl-crossplane-stack-init
+++ b/bin/kubectl-crossplane-stack-init
@@ -18,12 +18,6 @@ set -x
 STACK_NAME=${1}
 INIT_DIR=${2:-$PWD}
 
-# Create dirs
-# Create manifest files
-# Create sample install file
-# Create Dockerfile
-# Create Makefile
-
 function create_dirs {
   mkdir -p config/stack
 }
@@ -97,7 +91,7 @@ EOF
 }
 
 function create_build {
-  cat > Dockerfile.stack <<'EOF'
+  cat > stack.Dockerfile <<'EOF'
 # Build the manager binary
 FROM golang:1.12.5 as builder
 
@@ -126,7 +120,7 @@ COPY --from=builder /workspace/manager .
 ENTRYPOINT ["/manager"]
 EOF
 
-  cat > env.stack <<EOF
+  cat > stack.env <<EOF
 # Image URL to use all building/pushing image targets
 IMG ?= ${STACK_NAME}:latest
 
@@ -136,8 +130,8 @@ LOCAL_OVERRIDES_DIR=config/samples/overrides
 CONFIG_SAMPLES_DIR=config/stack/samples
 EOF
 
-  cat > Makefile.stack <<'EOF'
-include env.stack
+  cat > stack.Makefile <<'EOF'
+include stack.env
 
 GO111MODULE ?= on
 export GO111MODULE
@@ -264,7 +258,7 @@ stack-uninstall:
 
 # Build the docker image
 docker-build: test
-	docker build --file Dockerfile.stack . -t ${IMG}
+	docker build --file stack.Dockerfile . -t ${IMG}
 	@echo "updating kustomize image patch file for manager resource"
 	@# The argument to sed -i and the subsequent rm make the in-place sed work well on MacOS.
 	@# There is no good way to do an in-place replacement with sed without leaving behind a

--- a/bin/kubectl-crossplane-stack-init
+++ b/bin/kubectl-crossplane-stack-init
@@ -302,6 +302,19 @@ docker-push:
 	docker push ${IMG}
 EOF
   echo 'Created stack.Makefile' >&2
+
+
+  if [ -f .gitignore ] ; then
+    grep -q 'stack-package/' .gitignore || cat >>.gitignore <<EOF
+
+# stack-package is a generated folder, and can be considered an intermediate
+# build artifact. We don't need to check it into version control.
+stack-package/
+EOF
+    echo 'Made sure stack-package/ is in .gitignore' >&2
+  else
+    echo 'No .gitignore found; not adding stack-package/ to .gitignore' >&2
+  fi
 }
 
 cd ${INIT_DIR}

--- a/bin/kubectl-crossplane-stack-init
+++ b/bin/kubectl-crossplane-stack-init
@@ -16,8 +16,6 @@ if [[ $# -lt 1 ]] ; then
   exit 1
 fi
 
-set -x
-
 STACK_NAME=${1}
 # For kubernetes fields, we aren't able to use slashes, and
 # slashes are common for docker image names. So we remove the
@@ -34,11 +32,16 @@ function create_manifest {
   touch config/stack/manifests/app.yaml
   cat > config/stack/manifests/app.yaml <<'EOF'
 EOF
+
+  echo 'Created config/stack/manifests/app.yaml' >&2
+
   touch config/stack/manifests/rbac.yaml
   cat > config/stack/manifests/rbac.yaml <<'EOF'
 ---
 # Put your rbac rules here
 EOF
+  echo 'Created config/stack/manifests/rbac.yaml' >&2
+
   touch config/stack/manifests/install.yaml
   cat > config/stack/manifests/install.yaml <<EOF
 apiVersion: apps/v1
@@ -71,6 +74,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
 EOF
+  echo 'Created config/stack/manifests/install.yaml' >&2
 }
 
 function create_samples {
@@ -85,6 +89,7 @@ spec:
   source: localhost:5000
   package: "${KUBEY_STACK_NAME}"
 EOF
+  echo 'Created config/stack/samples/local.install.stack.yaml' >&2
 
   cat > config/stack/samples/install.stack.yaml <<EOF
 ---
@@ -95,7 +100,9 @@ metadata:
 spec:
   package: "${KUBEY_STACK_NAME}"
 EOF
+  echo 'Created config/stack/samples/install.stack.yaml' >&2
 
+  mkdir -p config/stack/samples/overrides
   cat > config/stack/samples/overrides/install.yaml <<EOF
 spec:
   template:
@@ -104,6 +111,7 @@ spec:
       - name: "${KUBEY_STACK_NAME}-controller"
         image: "localhost:5000/${STACK_NAME}"
 EOF
+  echo 'Created config/stack/samples/overrides/install.yaml' >&2
 }
 
 function create_build {
@@ -135,6 +143,7 @@ COPY stack-package /
 COPY --from=builder /workspace/manager .
 ENTRYPOINT ["/manager"]
 EOF
+  echo 'Created stack.Dockerfile' >&2
 
   cat > stack.env <<EOF
 # Image URL to use all building/pushing image targets
@@ -142,9 +151,10 @@ IMG ?= ${STACK_NAME}:latest
 
 CRD_DIR=config/crd/bases
 STACK_PACKAGE_REGISTRY_SOURCE=config/stack/manifests
-LOCAL_OVERRIDES_DIR=config/samples/overrides
+LOCAL_OVERRIDES_DIR=config/stack/samples/overrides
 CONFIG_SAMPLES_DIR=config/stack/samples
 EOF
+  echo 'Created stack.env' >&2
 
   cat > stack.Makefile <<'EOF'
 include stack.env
@@ -283,10 +293,13 @@ docker-build: test
 	rm ./config/default/manager_image_patch.yaml.bak
 
 EOF
+  echo 'Created stack.Makefile' >&2
 }
 
+cd ${INIT_DIR}
 create_dirs
 create_manifest
 create_samples
 create_build
 
+  echo 'Done!' >&2

--- a/bin/kubectl-crossplane-stack-publish
+++ b/bin/kubectl-crossplane-stack-publish
@@ -3,4 +3,4 @@
 set -e
 set -x
 
-make -f Makefile.stack publish
+make -f stack.Makefile publish

--- a/bin/kubectl-crossplane-stack-publish
+++ b/bin/kubectl-crossplane-stack-publish
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+make -f Makefile.stack publish


### PR DESCRIPTION
## Overview

As part of working with crossplane stacks, we want the workflow to be nice to use. This is the first pass at adding some commands for stack developer workflow:

* Init, which initializes the scaffolding to stackify a project (currently only kubebuilder 2)
* Build, which builds a stack (after its binaries and generated yamls have been build)
* Publish, which pushes a built stack into a registry

## Testing done

I have the start of a quick start guide which I've been using to test the flow locally. The idea is that the user starts from scratch, creates a hello world stack, and validates it locally. I have recently gotten things running smoothly with crossplaneio/crossplane@d9783258f6538db78c9163e6860ee2100db9ca16 .

## Notes for reviewers

This is more of an FYI than a pull request that will block on reviews, but feel free to leave comments! I'll revisit them later if the changeset has already been merged.