### PR TITLE
docs: update installation to point to master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 Get the commands on the PATH so `kubectl` can pick them up:
 ```
-curl -o /usr/local/bin/kubectl-crossplane-stack-build https://raw.githubusercontent.com/suskin/crossplane-stack-cli/first-cli/bin/kubectl-crossplane-stack-build -s >/dev/null
-curl -o /usr/local/bin/kubectl-crossplane-stack-init https://raw.githubusercontent.com/suskin/crossplane-stack-cli/first-cli/bin/kubectl-crossplane-stack-init -s >/dev/null
-curl -o /usr/local/bin/kubectl-crossplane-stack-publish https://raw.githubusercontent.com/suskin/crossplane-stack-cli/first-cli/bin/kubectl-crossplane-stack-publish -s >/dev/null
+curl -o /usr/local/bin/kubectl-crossplane-stack-build https://raw.githubusercontent.com/suskin/crossplane-stack-cli/master/bin/kubectl-crossplane-stack-build -s >/dev/null
+curl -o /usr/local/bin/kubectl-crossplane-stack-init https://raw.githubusercontent.com/suskin/crossplane-stack-cli/master/bin/kubectl-crossplane-stack-init -s >/dev/null
+curl -o /usr/local/bin/kubectl-crossplane-stack-publish https://raw.githubusercontent.com/suskin/crossplane-stack-cli/master/bin/kubectl-crossplane-stack-publish -s >/dev/null
 chmod +x /usr/local/bin/kubectl-crossplane-stack-*
 ```
 


### PR DESCRIPTION
## Overview
Previously, before the first version of the commands were merged, the
installation instructions pointed to the `first-cli` branch, but now
they should point to the `master` branch.

Really this should've been part of #2 , but I merged it a little too fast.